### PR TITLE
Fix Occasional SQS/ Lambda Invocation Bug

### DIFF
--- a/file-standardization-pipeline/file_standardization_pipeline/file_standardization_pipeline.py
+++ b/file-standardization-pipeline/file_standardization_pipeline/file_standardization_pipeline.py
@@ -185,7 +185,8 @@ class FileStandardizationPipelineStack(BaseStack):
             id="lambda_to_sqs_stage",
             environment_id=self._environment_id,
             code=lambda_code.from_asset("./file_standardization_pipeline/src/invoke_step_function"), 
-            handler="handler.lambda_handler"
+            handler="handler.lambda_handler",
+            batch_size=1
         )
 
         sqs_to_lambda_stage.function.add_environment("STEPFUNCTION", self._glue_transform_stage.state_machine.state_machine_arn)


### PR DESCRIPTION
When testing pipeline, occasionally, only three Step Functions would run, hence only three Glue Jobs would run, and only three tables would be populated in the Glue Catalog, despite there being 4 source files copied to S3.

The issue was, occasionally, two S3 Events would be polled from the SQS in the same Lambda invocation, causing only one Step Function run to be created (for the first file listed in the Lambda event payload).

The fix is a simple one liner, in which the batch size is set to 1 for the SQS queue within the SqsToLambdaStage, such that each S3 event will receive its own Lambda invocation. 

I have tested this on my own account, and it seems to have fixed the bug.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
