### PR TITLE
assign value to variable app and org using self._app and self.org ins…

### DIFF
--- a/sdlf-ddk-lightweight/data_lake/pipelines/standard_pipeline/standard_pipeline.py
+++ b/sdlf-ddk-lightweight/data_lake/pipelines/standard_pipeline/standard_pipeline.py
@@ -267,8 +267,8 @@ class StandardPipeline(BaseStack):
         # Create dataset stack
         stage_a_transform = config.get("stage_a_transform", "sdlf_light_transform")
         stage_b_transform = config.get("stage_b_transform", "sdlf_heavy_transform")
-        app = config.get("app", "datalake")
-        org = config.get("org", "aws")
+        app = self._app
+        org = self._org
 
         StandardDatasetStack(
             self,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Config file parameter.json does not contain the setting for "org" and "app", hence always the default value is used when assigning value to variable "org" and "app" in function register_dataset. This change sources the value for variable "org" and "app" from self._org and self.app to fix the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
