### PR TITLE
Update file-standardization.ts

### DIFF
--- a/file-standardization-pipeline/typescript/bin/file-standardization.ts
+++ b/file-standardization-pipeline/typescript/bin/file-standardization.ts
@@ -87,7 +87,7 @@ export class FileStandardizationPipelineStack extends ddk.BaseStack {
           targets: {
             s3Targets: [
               {
-                path: `s3://${this.bucket.bucketName}/output}`
+                path: `s3://${this.bucket.bucketName}/output`
               }
             ]
           },


### PR DESCRIPTION
Removing '}' as it is a typo.  If it remains, the Glue tables will not be created.
