### PR TITLE
Add archive deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # AWS DDK Examples
 
+> [!WARNING]
+> **This repository has been archived and is no longer maintained.**
+> 
+> This project is no longer actively developed or supported. The repository has been made read-only for historical reference.
+
 This repository contains a list of example projects for the [AWS DataOps Development Kit (DDK)](https://awslabs.github.io/aws-ddk/).
 
 ## Table of Contents


### PR DESCRIPTION
## Description

Adds a prominent deprecation/archive notice to the top of the README to inform visitors that this repository is no longer actively maintained.

## Changes

- Added a GitHub-flavored `[!WARNING]` callout block immediately after the H1 heading in `README.md`
- The notice communicates that the repo is archived, read-only, and preserved for historical reference

## Why

Users landing on this repository should immediately see that it is no longer maintained so they can set expectations accordingly.